### PR TITLE
Added code to reformulate and compute the highpoint relaxation

### DIFF
--- a/pao/bilevel/plugins/__init__.py
+++ b/pao/bilevel/plugins/__init__.py
@@ -22,6 +22,7 @@ def load():
     """
     import pao.bilevel.plugins.dual
     import pao.bilevel.plugins.lcp
+    import pao.bilevel.plugins.highpoint
     import pao.bilevel.solvers.solver1
     import pao.bilevel.solvers.solver2
     import pao.bilevel.solvers.solver3

--- a/pao/bilevel/plugins/dual.py
+++ b/pao/bilevel/plugins/dual.py
@@ -40,7 +40,7 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
         self._preprocess('pao.bilevel.linear_dual', model)
         self._fix_all()
 
-        for (key1,key2), sub in self.submodel.items():
+        for key, sub in self.submodel.items():
             #
             # Generate the dual block
             #
@@ -79,8 +79,8 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
             #
             # Add the dual block
             #
-            setattr(model, key1+'_dual', dual)
-            model.reclassify_component_type(key1+'_dual', Block)
+            setattr(model, key +'_dual', dual)
+            model.reclassify_component_type(key +'_dual', Block)
             #
             # Unfix the upper variables
             #

--- a/pao/bilevel/plugins/highpoint.py
+++ b/pao/bilevel/plugins/highpoint.py
@@ -16,19 +16,56 @@ import six
 
 from pyomo.core import Block, VarList, ConstraintList, Objective,\
                        Var, Constraint, maximize, ComponentUID, Set,\
-                       TransformationFactory
-from pyomo.repn import generate_standard_repn
-from pyomo.mpec import ComplementarityList, complements
+                       TransformationFactory, Model, Reference
+from pao.bilevel.components import SubModel
 from .transform import BaseBilevelTransformation
 import logging
 
 logger = logging.getLogger(__name__)
 
-def create_submodel_hp_block(): pass
+
+def create_submodel_hp_block(instance, submodel):
+    """
+    Creates highpoint relaxation with the given specified submodel
+    """
+    block = Block(concrete=True)
+
+    # get the objective for the master problem
+    for c in instance.component_objects(Objective, descend_into=False):
+        if c.parent_block() == instance:
+            block.add_component(c.name, Reference(c))
+
+    # get the variables of the model (if there are more submodels, then
+    # extraneous variables may be added to the block)
+    for c in instance.component_objects(Var, descend_into=False):
+        if c.parent_block() == instance:
+            block.add_component(c.name, Reference(c))
+
+    # get the constraints from the main model
+    for c in instance.component_objects(Constraint, descend_into=False):
+        if c.parent_block() == instance:
+            block.add_component(c.name, Reference(c))
+
+    # get the constraints from the submodel of interest
+    for _block in instance.component_objects(Block, descend_into=False):
+        if _block == submodel:
+            for c in _block.component_objects(Constraint, descend_into=False):
+                check = block.find_component(c.name) # checks to see if a constraint by the same name is on the main block
+                # this is feasible due to local scoping of each block, but we need unique names for the highpoint relaxation
+                if check is None:
+                    block.add_component(c.name, Reference(c))
+                else:
+                    block.add_component(submodel.name + '_' + c.name, Reference(c))
+
+    # deactivate the highpoint relaxation
+    block.deactivate()
+
+    return block
+
 
 @TransformationFactory.register('pao.bilevel.highpoint',
-                                doc="Generate a highpoint representation of the model")
-class LinearComplementarityBilevelTransformation(BaseBilevelTransformation):
+                                doc="Generate a highpoint relaxation of the model")
+class LinearHighpointTransformation(BaseBilevelTransformation):
     """
     This transformation creates a block using a SubModel object,
     which contains objective and constraint set of upper-level, and constraint set of lower-level for
@@ -36,29 +73,32 @@ class LinearComplementarityBilevelTransformation(BaseBilevelTransformation):
     """
 
     def _apply_to(self, model, **kwds):
-        deterministic = kwds.pop('deterministic', False)
         submodel_name = kwds.pop('submodel', None)
+
         #
         # Process options
         #
         self._preprocess('pao.bilevel.highpoint', model)
-        for (key1,key2), sub in self.submodel.items():
-            model.reclassify_component_type(sub, Block)
 
+        def _sub_transformation(model, sub, key):
+            model.reclassify_component_type(sub, Block)
             #
-            # Create a block with highpoint formulation
+            # Create a block with optimality conditions
             #
-            setattr(model, str(key1)+'_hp',
-                    create_submodel_hp_block(model, sub, deterministic,
-                                              self.fixed_vardata[(key1,key2)]))
+            setattr(model, key +'_hp',
+                    create_submodel_hp_block(model, sub))
             model._transformation_data['pao.bilevel.highpoint'].submodel_cuid =\
                 ComponentUID(sub)
             model._transformation_data['pao.bilevel.highpoint'].block_cuid =\
-                ComponentUID(getattr(model, str(key1)+'_hp'))
-            #
-            # Disable the original submodel and
-            #
-            for data in sub.component_map(active=True).values():
-                if not isinstance(data, Var) and not isinstance(data, Set):
-                    data.deactivate()
+                ComponentUID(getattr(model, key +'_hp'))
+
+        if not submodel_name is None:
+            lookup = {value: key for key, value in self.submodel}
+            sub = getattr(model,submodel_name)
+            if sub:
+                _sub_transformation(model, sub, lookup[sub])
+            return
+
+        for key, sub in self.submodel.items():
+            _sub_transformation(model, sub, key)
 

--- a/pao/bilevel/plugins/transform.py
+++ b/pao/bilevel/plugins/transform.py
@@ -73,11 +73,11 @@ class BaseBilevelTransformation(Transformation):
                     logger.error(e)
                     raise RuntimeError(e)
                 instance._transformation_data[tname].submodel = [name]
-                nest_level = self._nest_level(submodel)
+                #nest_level = self._nest_level(submodel)
                 if submodel._fixed:
-                    self._fixed_vardata[(name,nest_level)] = [vardata for v in submodel._fixed for vardata in v.values()]
-                    instance._transformation_data[tname].fixed = [ComponentUID(v) for v in self._fixed_vardata[(name,nest_level)]]
-                    self._submodel[(name,nest_level)] = submodel
+                    self._fixed_vardata[name] = [vardata for v in submodel._fixed for vardata in v.values()]
+                    instance._transformation_data[tname].fixed = [ComponentUID(v) for v in self._fixed_vardata[name]]
+                    self._submodel[name] = submodel
                 else:
                     e = "Must specify 'fixed' or 'unfixed' options"
                     logger.error(e)
@@ -89,7 +89,7 @@ class BaseBilevelTransformation(Transformation):
         """
         Fix the upper variables
         """
-        for (key1,key2),vardata in self._fixed_vardata.items():
+        for key,vardata in self._fixed_vardata.items():
             for v in vardata:
                 if not v.fixed:
                     self._fixed_ids.add(id(v))
@@ -99,7 +99,7 @@ class BaseBilevelTransformation(Transformation):
         """
         Unfix the upper variables
         """
-        for (key1,key2),vardata in self._fixed_vardata.items():
+        for key,vardata in self._fixed_vardata.items():
             for v in vardata:
                 if id(v) in self._fixed_ids:
                     v.fixed = False

--- a/pao/bilevel/solvers/solver5.py
+++ b/pao/bilevel/solvers/solver5.py
@@ -31,7 +31,7 @@ from pyomo.core import TransformationFactory, Var, Set
 
 @pyomo.opt.SolverFactory.register('pao.bilevel.norvep',
                                   doc='Solver for near-optimal vertex enumeration procedure')
-class BilevelSolver4(pyomo.opt.OptSolver):
+class BilevelSolver5(pyomo.opt.OptSolver):
     """
     A solver that performs global optimization of bilevel
     quadratic programs.
@@ -47,6 +47,8 @@ class BilevelSolver4(pyomo.opt.OptSolver):
         # pyomo.opt.OptSolver._presolve(self, *args, **kwds)
 
     def _apply_solver(self): pass
+
+
 
         # construct the high-point problem (LL feasible, no LL objective)
         # s0 <- solve the high-point

--- a/pao/bilevel/tests/aux/besancon27.py
+++ b/pao/bilevel/tests/aux/besancon27.py
@@ -1,0 +1,39 @@
+#  ___________________________________________________________________________
+#
+#  Pyomo: Python Optimization Modeling Objects
+#  Copyright 2017 National Technology and Engineering Solutions of Sandia, LLC
+#  Under the terms of Contract DE-NA0003525 with National Technology and 
+#  Engineering Solutions of Sandia, LLC, the U.S. Government retains certain 
+#  rights in this software.
+#  This software is distributed under the 3-clause BSD License.
+#  ___________________________________________________________________________
+
+# Example 2.7 from
+#
+# Near-Optimal Robust Bilevel Optimization
+#   M. Besancon, M. F. Anjos and L. Brotcorne
+#   arXiv:1908.04040v5 (2019)
+from pyomo.environ import *
+from pao.bilevel import *
+
+def pyomo_create_model():
+
+    model = ConcreteModel()
+    model.x = Var(within=NonNegativeReals)
+    model.v = Var()
+    model.o = Objective(expr=model.x, sense=minimize)
+    model.c1 = Constraint(expr=model.v >= 1 - model.x/10)
+
+    # Create a submodel
+    # The argument indicates the lower-level decision variables
+    model.sub = SubModel(fixed=model.x)
+    model.sub.o = Objective(expr=model.v, sense=maximize)
+    model.sub.c1 = Constraint(expr=1 + model.x/10 >= model.v)
+
+    return model
+
+
+# unique optimal solution (x,v) = (0,1)
+
+if __name__ == "__main__":
+    pyomo_create_model()

--- a/pao/bilevel/tests/aux/reformulation/besancon27.txt
+++ b/pao/bilevel/tests/aux/reformulation/besancon27.txt
@@ -1,0 +1,58 @@
+2 Var Declarations
+    v : Size=1, Index=None
+        Key  : Lower : Value : Upper : Fixed : Stale : Domain
+        None :  None :  None :  None : False :  True :  Reals
+    x : Size=1, Index=None
+        Key  : Lower : Value : Upper : Fixed : Stale : Domain
+        None :     0 :  None :  None : False :  True : NonNegativeReals
+1 Objective Declarations
+    o : Size=1, Index=None, Active=True
+        Key  : Active : Sense    : Expression
+        None :   True : minimize :          x
+1 Constraint Declarations
+    c1 : Size=1, Index=None, Active=True
+        Key  : Lower : Body          : Upper : Active
+        None :  -Inf : 1 - 0.1*x - v :   0.0 :   True
+2 Block Declarations
+    sub : Size=1, Index=None, Active=True
+        1 Objective Declarations
+            o : Size=1, Index=None, Active=True
+                Key  : Active : Sense    : Expression
+                None :   True : maximize :          v
+        1 Constraint Declarations
+            c1 : Size=1, Index=None, Active=True
+                Key  : Lower : Body            : Upper : Active
+                None :  -Inf : v - (1 + 0.1*x) :   0.0 :   True
+        2 Declarations: o c1
+    sub_hp : Size=1, Index=None, Active=False
+        5 Set Declarations
+            c1_index : Dim=0, Dimen=1, Size=1, Domain=None, Ordered=False, Bounds=(None, None)
+                [None]
+            o_index : Dim=0, Dimen=1, Size=1, Domain=None, Ordered=False, Bounds=(None, None)
+                [None]
+            sub.c1_index : Dim=0, Dimen=1, Size=1, Domain=None, Ordered=False, Bounds=(None, None)
+                [None]
+            v_index : Dim=0, Dimen=1, Size=1, Domain=None, Ordered=False, Bounds=(None, None)
+                [None]
+            x_index : Dim=0, Dimen=1, Size=1, Domain=None, Ordered=False, Bounds=(None, None)
+                [None]
+        2 Var Declarations
+            v : Size=1, Index=sub_hp.v_index
+                Key  : Lower : Value : Upper : Fixed : Stale : Domain
+                None :  None :  None :  None : False :  True :  Reals
+            x : Size=1, Index=sub_hp.x_index
+                Key  : Lower : Value : Upper : Fixed : Stale : Domain
+                None :     0 :  None :  None : False :  True : NonNegativeReals
+        1 Objective Declarations
+            o : Size=1, Index=sub_hp.o_index, Active=True
+                Key  : Active : Sense    : Expression
+                None :   True : minimize :          x
+        2 Constraint Declarations
+            c1 : Size=1, Index=sub_hp.c1_index, Active=True
+                Key  : Lower : Body          : Upper : Active
+                None :  -Inf : 1 - 0.1*x - v :   0.0 :   True
+            sub.c1 : Size=1, Index=sub_hp.sub.c1_index, Active=True
+                Key  : Lower : Body            : Upper : Active
+                None :  -Inf : v - (1 + 0.1*x) :   0.0 :   True
+        10 Declarations: o_index o x_index x v_index v c1_index c1 sub.c1_index sub.c1
+6 Declarations: x v o c1 sub sub_hp

--- a/pao/bilevel/tests/aux/solution/besancon27.txt
+++ b/pao/bilevel/tests/aux/solution/besancon27.txt
@@ -1,0 +1,40 @@
+# ==========================================================
+# = Solver Results                                         =
+# ==========================================================
+# ----------------------------------------------------------
+#   Problem Information
+# ----------------------------------------------------------
+Problem:
+- Name: x3
+  Lower bound: 0.0
+  Upper bound: 0.0
+  Number of objectives: 1
+  Number of constraints: 3
+  Number of variables: 3
+  Number of binary variables: 0
+  Number of integer variables: 0
+  Number of continuous variables: 3
+  Number of nonzeros: 5
+  Sense: minimize
+# ----------------------------------------------------------
+#   Solver Information
+# ----------------------------------------------------------
+Solver:
+- Status: ok
+  Return code: 0
+  Message: Model was solved to optimality (subject to tolerances), and an optimal solution is available.
+  Termination condition: optimal
+  Termination message: Model was solved to optimality (subject to tolerances), and an optimal solution is available.
+  Wall time: 0.00135397911072
+  Error rc: 0
+  Time: 0.26924586296081543
+# ----------------------------------------------------------
+#   Solution Information
+# ----------------------------------------------------------
+Solution:
+- number of solutions: 0
+  number of solutions displayed: 0
+- Status: optimal
+  Objective:
+    o:
+      Value: 0.0


### PR DESCRIPTION
This code  update includes a transformation package that creates the highpoint relaxation on a deactivated block of the bilevel concrete model. All highpoint relaxation blocks are named with the convention 's%_hp' where s% is the string name of the actual SubModel, which we want to check that the upper level has feasible solutions to this lower level  problem. There is some test code example for reformulation and solution in test_highpoint.py. These unitcases need to be extended.