### PR TITLE
Updates to varref, dataref and creating highpoint

### DIFF
--- a/pao/bilevel/components.py
+++ b/pao/bilevel/components.py
@@ -16,7 +16,7 @@ This module defines Pyomo components used to declare bilevel programs.
 
 __all__ = ("SubModel",)
 
-from pyomo.core import Reference, Var, Transformation
+from pyomo.core import Reference, Var, Transformation, Param, Set
 #pylint: disable-msg=too-many-ancestors
 
 from pyomo.core import SimpleBlock, ModelComponentFactory, Component
@@ -53,16 +53,22 @@ def varref(model, origin=None, vars=None):
     for _var in var_list:
         model.add_component(_var.name, Reference(_var))
 
-def dataref(model, origin=None, vars=None):
+
+def dataref(model, origin=None):
     """
     This helper function enables params and sets to be locally referenced
     from within a given block on the model, since all variables on
     a bilevel model exist only on the parent_block() for ConcreteModel()
     """
+    # default to parent block
+    if not origin:
+        origin = model.parent_block()
 
+    for p in origin.component_objects(Param, descend_into=False):
+        model.add_component(p.name, Reference(p))
 
-#def dataref:
-# include set and param references
+    for s in origin.component_objects(Set, descend_into=False):
+        model.add_component(s.name, Reference(s))
 
 
 @ModelComponentFactory.register("A submodel in a bilevel program")

--- a/pao/bilevel/components.py
+++ b/pao/bilevel/components.py
@@ -29,12 +29,11 @@ def varref(model, origin=None, vars=None):
     """
 
     if not origin:
-        origin = model.parent_block()
+        origin = model.root_block()
 
     if not vars:
         for c in origin.component_objects(Var, descend_into=False):
-            if c.parent_block() == origin:
-                model.add_component(c.name, Reference(c))
+            model.add_component(c.name, Reference(c))
 
 @ModelComponentFactory.register("A submodel in a bilevel program")
 class SubModel(SimpleBlock):
@@ -50,6 +49,7 @@ class SubModel(SimpleBlock):
         #
         _rule = kwargs.pop('rule', None)
         _fixed = kwargs.pop('fixed', None)
+
         #_var = kwargs.pop('var', None)
         #
         # Initialize the SimpleBlock

--- a/pao/bilevel/components.py
+++ b/pao/bilevel/components.py
@@ -21,6 +21,7 @@ from pyomo.core import Reference, Var, Transformation
 
 from pyomo.core import SimpleBlock, ModelComponentFactory, Component
 
+
 def varref(model, origin=None, vars=None):
     """
     This helper function enables variables to be locally referenced
@@ -28,12 +29,41 @@ def varref(model, origin=None, vars=None):
     a bilevel model exist only on the parent_block() for ConcreteModel()
     """
 
+    # default to parent block
     if not origin:
-        origin = model.root_block()
+        origin = model.parent_block()
 
-    if not vars:
-        for c in origin.component_objects(Var, descend_into=False):
-            model.add_component(c.name, Reference(c))
+    # intersection of 2 Pyomo var lists
+    def _intersection(list1, list2):
+        list3 = list()
+        for l1 in list1:
+            for l2 in list2:
+                if l1.name == l2.name:
+                    list3.append(l1)
+        return list3
+
+    # list of variables to add references for to the nested block; if vars is specified,
+    # vars must exist on the origin block
+    var_list = [var for var in origin.component_objects(Var, descend_into=False)]
+    if vars:
+        var_list = _intersection(vars, var_list)
+
+    # if variable name already exists on nested block, raise a RuntimeError (in Pyomo); otherwise add reference
+    # for variable onto the nested block
+    for _var in var_list:
+        model.add_component(_var.name, Reference(_var))
+
+def dataref(model, origin=None, vars=None):
+    """
+    This helper function enables params and sets to be locally referenced
+    from within a given block on the model, since all variables on
+    a bilevel model exist only on the parent_block() for ConcreteModel()
+    """
+
+
+#def dataref:
+# include set and param references
+
 
 @ModelComponentFactory.register("A submodel in a bilevel program")
 class SubModel(SimpleBlock):

--- a/pao/bilevel/plugins/highpoint.py
+++ b/pao/bilevel/plugins/highpoint.py
@@ -17,88 +17,124 @@ import six
 from pyomo.core import Block, VarList, ConstraintList, Objective,\
                        Var, Constraint, maximize, ComponentUID, Set,\
                        TransformationFactory, Model, Reference
-from pao.bilevel.components import SubModel
-from .transform import BaseBilevelTransformation
+#from pao.bilevel.components import SubModel
+#from .transform import BaseBilevelTransformation
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-def create_submodel_hp_block(instance, submodel):
+def create_submodel_hp_block(instance):
     """
-    Creates highpoint relaxation with the given specified submodel
+    Creates highpoint relaxation with the given specified model; does
+    not include any submodel or block that is deactivated
     """
+    if not instance.active:
+        raise RuntimeError("The current model is deactivated and cannot build the highpoint relaxation.")
+
     block = Block(concrete=True)
 
     # get the objective for the master problem
     for c in instance.component_objects(Objective, descend_into=False):
-        if c.parent_block() == instance:
-            block.add_component(c.name, Reference(c))
+        block.add_component(c.name, Reference(c))
 
     # get the variables of the model (if there are more submodels, then
     # extraneous variables may be added to the block)
     for c in instance.component_objects(Var, descend_into=False):
-        if c.parent_block() == instance:
-            block.add_component(c.name, Reference(c))
+        block.add_component(c.name, Reference(c))
 
     # get the constraints from the main model
     for c in instance.component_objects(Constraint, descend_into=False):
-        if c.parent_block() == instance:
-            block.add_component(c.name, Reference(c))
+        block.add_component(c.name, Reference(c))
 
     # get the constraints from the submodel of interest
-    for _block in instance.component_objects(Block, descend_into=False):
-        if _block == submodel:
+    # add anything to the hpr that is deactivated
+    # allow user to pass in their HPR block
+    def _process_nested_block(model):
+        for _block in model.component_objects(Block, descend_into=False):
             for c in _block.component_objects(Constraint, descend_into=False):
-                check = block.find_component(c.name) # checks to see if a constraint by the same name is on the main block
-                # this is feasible due to local scoping of each block, but we need unique names for the highpoint relaxation
+
+                # modify the name of the block
+                check = _block.find_component(c.name)
                 if check is None:
                     block.add_component(c.name, Reference(c))
                 else:
-                    block.add_component(submodel.name + '_' + c.name, Reference(c))
+                    block.add_component(_block.name + '_' + c.name, Reference(c))
+            _process_nested_block(_block)
+
+    _process_nested_block(instance)
 
     # deactivate the highpoint relaxation
     block.deactivate()
 
     return block
 
+#
+# @TransformationFactory.register('pao.bilevel.highpoint',
+#                                 doc="Generate a highpoint relaxation of the model")
+# class LinearHighpointTransformation(BaseBilevelTransformation):
+#     """
+#     This transformation creates a block using a SubModel object,
+#     which contains objective and constraint set of upper-level, and constraint set of lower-level for
+#     lower-level feasibility.
+#     """
+#
+#     def _apply_to(self, model, **kwds):
+#         submodel_name = kwds.pop('submodel', None)
+#
+#         #
+#         # Process options
+#         #
+#         self._preprocess('pao.bilevel.highpoint', model)
+#
+#         def _sub_transformation(model, sub, key):
+#             model.reclassify_component_type(sub, Block)
+#             #
+#             # Create a block with optimality conditions
+#             #
+#             setattr(model, key +'_hp',
+#                     create_submodel_hp_block(model, sub))
+#             model._transformation_data['pao.bilevel.highpoint'].submodel_cuid =\
+#                 ComponentUID(sub)
+#             model._transformation_data['pao.bilevel.highpoint'].block_cuid =\
+#                 ComponentUID(getattr(model, key +'_hp'))
+#
+#         if not submodel_name is None:
+#             lookup = {value: key for key, value in self.submodel}
+#             sub = getattr(model,submodel_name)
+#             if sub:
+#                 _sub_transformation(model, sub, lookup[sub])
+#             return
+#
+#         for key, sub in self.submodel.items():
+#             _sub_transformation(model, sub, key)
+#
 
-@TransformationFactory.register('pao.bilevel.highpoint',
-                                doc="Generate a highpoint relaxation of the model")
-class LinearHighpointTransformation(BaseBilevelTransformation):
-    """
-    This transformation creates a block using a SubModel object,
-    which contains objective and constraint set of upper-level, and constraint set of lower-level for
-    lower-level feasibility.
-    """
+if __name__ == '__main__':
+    from pyomo.environ import *
+    from pao.bilevel import *
 
-    def _apply_to(self, model, **kwds):
-        submodel_name = kwds.pop('submodel', None)
+    M = ConcreteModel()
+    M.x1 = Var(bounds=(0, None))
+    M.x2 = Var(within=Binary)
+    M.y1 = Var(bounds=(1, None))
+    M.y2 = Var(bounds=(-100, 2))
+    M.y3 = Var(bounds=(None, None))
+    M.y4 = Var(bounds=(3, 4))
+    M.o = Objective(expr=M.x1 - 4 * M.y1)
 
-        #
-        # Process options
-        #
-        self._preprocess('pao.bilevel.highpoint', model)
+    M.sub = SubModel(fixed=(M.x1, M.x2))
+    M.sub.o = Objective(expr=11 * M.x2 + 12 * M.x2 * M.y1 + M.y2 + 9 * M.y3)
+    M.sub.c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
+    M.sub.c2 = Constraint(expr=20 <= 2 * M.x1 + 6 * M.y1 + 14 * M.x2 * M.y2 + 10 * M.y3)
+    M.sub.c3 = Constraint(expr=32 == 4 * M.x1 + 8 * M.y1 + 15 * M.x2 * M.y4)
+    M.sub.c4 = Constraint(expr=inequality(22, 3 * M.x1 + 7 * M.y1 + 16 * M.x2 * M.y3, 28))
 
-        def _sub_transformation(model, sub, key):
-            model.reclassify_component_type(sub, Block)
-            #
-            # Create a block with optimality conditions
-            #
-            setattr(model, key +'_hp',
-                    create_submodel_hp_block(model, sub))
-            model._transformation_data['pao.bilevel.highpoint'].submodel_cuid =\
-                ComponentUID(sub)
-            model._transformation_data['pao.bilevel.highpoint'].block_cuid =\
-                ComponentUID(getattr(model, key +'_hp'))
+    M.T = range(2)
+    M.block = Block(M.T)
 
-        if not submodel_name is None:
-            lookup = {value: key for key, value in self.submodel}
-            sub = getattr(model,submodel_name)
-            if sub:
-                _sub_transformation(model, sub, lookup[sub])
-            return
+    for t in M.T:
+        M.block[t].c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
 
-        for key, sub in self.submodel.items():
-            _sub_transformation(model, sub, key)
-
+    M.hp = create_submodel_hp_block(M)
+    M.hp.pprint()

--- a/pao/bilevel/plugins/highpoint.py
+++ b/pao/bilevel/plugins/highpoint.py
@@ -60,61 +60,15 @@ class LinearHighpointTransformation(BaseBilevelTransformation):
     """
 
     def _apply_to(self, model, **kwds):
-        submodel_name = kwds.pop('submodel', None)
-
-        #
-        # Process options
-        #
         self._preprocess('pao.bilevel.highpoint', model)
 
-        def _sub_transformation(model, sub, key):
-            model.reclassify_component_type(sub, Block)
-            #
-            # Create a block with optimality conditions
-            #
-            setattr(model, key +'_hp',
-                    create_submodel_hp_block(model, sub))
-            model._transformation_data['pao.bilevel.highpoint'].submodel_cuid =\
-                ComponentUID(sub)
-            model._transformation_data['pao.bilevel.highpoint'].block_cuid =\
-                ComponentUID(getattr(model, key +'_hp'))
-
-        if not submodel_name is None:
-            lookup = {value: key for key, value in self.submodel}
-            sub = getattr(model,submodel_name)
-            if sub:
-                _sub_transformation(model, sub, lookup[sub])
-            return
-
         for key, sub in self.submodel.items():
-            _sub_transformation(model, sub, key)
+            model.reclassify_component_type(sub, Block)
 
+        setattr(model, 'hpr',
+                    create_submodel_hp_block(model))
 
-# if __name__ == '__main__':
-#     from pyomo.environ import *
-#     from pao.bilevel import *
-#
-#     M = ConcreteModel()
-#     M.x1 = Var(bounds=(0, None))
-#     M.x2 = Var(within=Binary)
-#     M.y1 = Var(bounds=(1, None))
-#     M.y2 = Var(bounds=(-100, 2))
-#     M.y3 = Var(bounds=(None, None))
-#     M.y4 = Var(bounds=(3, 4))
-#     M.o = Objective(expr=M.x1 - 4 * M.y1)
-#
-#     M.sub = SubModel(fixed=(M.x1, M.x2))
-#     M.sub.o = Objective(expr=11 * M.x2 + 12 * M.x2 * M.y1 + M.y2 + 9 * M.y3)
-#     M.sub.c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
-#     M.sub.c2 = Constraint(expr=20 <= 2 * M.x1 + 6 * M.y1 + 14 * M.x2 * M.y2 + 10 * M.y3)
-#     M.sub.c3 = Constraint(expr=32 == 4 * M.x1 + 8 * M.y1 + 15 * M.x2 * M.y4)
-#     M.sub.c4 = Constraint(expr=inequality(22, 3 * M.x1 + 7 * M.y1 + 16 * M.x2 * M.y3, 28))
-#
-#     M.T = range(2)
-#     M.block = Block(M.T)
-#
-#     for t in M.T:
-#         M.block[t].c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
-#
-#     M.hp = create_submodel_hp_block(M)
-#     M.hp.pprint()
+        model._transformation_data['pao.bilevel.highpoint'].submodel_cuid = \
+            ComponentUID(model)
+        model._transformation_data['pao.bilevel.highpoint'].block_cuid = \
+            ComponentUID(getattr(model, 'hpr'))

--- a/pao/bilevel/plugins/highpoint.py
+++ b/pao/bilevel/plugins/highpoint.py
@@ -17,8 +17,8 @@ import six
 from pyomo.core import Block, VarList, ConstraintList, Objective,\
                        Var, Constraint, maximize, ComponentUID, Set,\
                        TransformationFactory, Model, Reference
-#from pao.bilevel.components import SubModel
-#from .transform import BaseBilevelTransformation
+from pao.bilevel.components import SubModel
+from .transform import BaseBilevelTransformation
 import logging
 
 logger = logging.getLogger(__name__)
@@ -29,9 +29,6 @@ def create_submodel_hp_block(instance):
     Creates highpoint relaxation with the given specified model; does
     not include any submodel or block that is deactivated
     """
-    if not instance.active:
-        raise RuntimeError("The current model is deactivated and cannot build the highpoint relaxation.")
-
     block = Block(concrete=True)
 
     # get the objective for the master problem
@@ -40,101 +37,84 @@ def create_submodel_hp_block(instance):
 
     # get the variables of the model (if there are more submodels, then
     # extraneous variables may be added to the block)
-    for c in instance.component_objects(Var, descend_into=False):
+    for c in instance.component_objects(Var, sort=True, descend_into=True, active=True):
         block.add_component(c.name, Reference(c))
 
     # get the constraints from the main model
-    for c in instance.component_objects(Constraint, descend_into=False):
+    for c in instance.component_objects(Constraint, sort=True, descend_into=True, active=True):
         block.add_component(c.name, Reference(c))
-
-    # get the constraints from the submodel of interest
-    # add anything to the hpr that is deactivated
-    # allow user to pass in their HPR block
-    def _process_nested_block(model):
-        for _block in model.component_objects(Block, descend_into=False):
-            for c in _block.component_objects(Constraint, descend_into=False):
-
-                # modify the name of the block
-                check = _block.find_component(c.name)
-                if check is None:
-                    block.add_component(c.name, Reference(c))
-                else:
-                    block.add_component(_block.name + '_' + c.name, Reference(c))
-            _process_nested_block(_block)
-
-    _process_nested_block(instance)
 
     # deactivate the highpoint relaxation
     block.deactivate()
 
     return block
 
-#
-# @TransformationFactory.register('pao.bilevel.highpoint',
-#                                 doc="Generate a highpoint relaxation of the model")
-# class LinearHighpointTransformation(BaseBilevelTransformation):
-#     """
-#     This transformation creates a block using a SubModel object,
-#     which contains objective and constraint set of upper-level, and constraint set of lower-level for
-#     lower-level feasibility.
-#     """
-#
-#     def _apply_to(self, model, **kwds):
-#         submodel_name = kwds.pop('submodel', None)
-#
-#         #
-#         # Process options
-#         #
-#         self._preprocess('pao.bilevel.highpoint', model)
-#
-#         def _sub_transformation(model, sub, key):
-#             model.reclassify_component_type(sub, Block)
-#             #
-#             # Create a block with optimality conditions
-#             #
-#             setattr(model, key +'_hp',
-#                     create_submodel_hp_block(model, sub))
-#             model._transformation_data['pao.bilevel.highpoint'].submodel_cuid =\
-#                 ComponentUID(sub)
-#             model._transformation_data['pao.bilevel.highpoint'].block_cuid =\
-#                 ComponentUID(getattr(model, key +'_hp'))
-#
-#         if not submodel_name is None:
-#             lookup = {value: key for key, value in self.submodel}
-#             sub = getattr(model,submodel_name)
-#             if sub:
-#                 _sub_transformation(model, sub, lookup[sub])
-#             return
-#
-#         for key, sub in self.submodel.items():
-#             _sub_transformation(model, sub, key)
-#
 
-if __name__ == '__main__':
-    from pyomo.environ import *
-    from pao.bilevel import *
+@TransformationFactory.register('pao.bilevel.highpoint',
+                                doc="Generate a highpoint relaxation of the model")
+class LinearHighpointTransformation(BaseBilevelTransformation):
+    """
+    This transformation creates a block using a SubModel object,
+    which contains objective and constraint set of upper-level, and constraint set of lower-level for
+    lower-level feasibility.
+    """
 
-    M = ConcreteModel()
-    M.x1 = Var(bounds=(0, None))
-    M.x2 = Var(within=Binary)
-    M.y1 = Var(bounds=(1, None))
-    M.y2 = Var(bounds=(-100, 2))
-    M.y3 = Var(bounds=(None, None))
-    M.y4 = Var(bounds=(3, 4))
-    M.o = Objective(expr=M.x1 - 4 * M.y1)
+    def _apply_to(self, model, **kwds):
+        submodel_name = kwds.pop('submodel', None)
 
-    M.sub = SubModel(fixed=(M.x1, M.x2))
-    M.sub.o = Objective(expr=11 * M.x2 + 12 * M.x2 * M.y1 + M.y2 + 9 * M.y3)
-    M.sub.c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
-    M.sub.c2 = Constraint(expr=20 <= 2 * M.x1 + 6 * M.y1 + 14 * M.x2 * M.y2 + 10 * M.y3)
-    M.sub.c3 = Constraint(expr=32 == 4 * M.x1 + 8 * M.y1 + 15 * M.x2 * M.y4)
-    M.sub.c4 = Constraint(expr=inequality(22, 3 * M.x1 + 7 * M.y1 + 16 * M.x2 * M.y3, 28))
+        #
+        # Process options
+        #
+        self._preprocess('pao.bilevel.highpoint', model)
 
-    M.T = range(2)
-    M.block = Block(M.T)
+        def _sub_transformation(model, sub, key):
+            model.reclassify_component_type(sub, Block)
+            #
+            # Create a block with optimality conditions
+            #
+            setattr(model, key +'_hp',
+                    create_submodel_hp_block(model, sub))
+            model._transformation_data['pao.bilevel.highpoint'].submodel_cuid =\
+                ComponentUID(sub)
+            model._transformation_data['pao.bilevel.highpoint'].block_cuid =\
+                ComponentUID(getattr(model, key +'_hp'))
 
-    for t in M.T:
-        M.block[t].c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
+        if not submodel_name is None:
+            lookup = {value: key for key, value in self.submodel}
+            sub = getattr(model,submodel_name)
+            if sub:
+                _sub_transformation(model, sub, lookup[sub])
+            return
 
-    M.hp = create_submodel_hp_block(M)
-    M.hp.pprint()
+        for key, sub in self.submodel.items():
+            _sub_transformation(model, sub, key)
+
+
+# if __name__ == '__main__':
+#     from pyomo.environ import *
+#     from pao.bilevel import *
+#
+#     M = ConcreteModel()
+#     M.x1 = Var(bounds=(0, None))
+#     M.x2 = Var(within=Binary)
+#     M.y1 = Var(bounds=(1, None))
+#     M.y2 = Var(bounds=(-100, 2))
+#     M.y3 = Var(bounds=(None, None))
+#     M.y4 = Var(bounds=(3, 4))
+#     M.o = Objective(expr=M.x1 - 4 * M.y1)
+#
+#     M.sub = SubModel(fixed=(M.x1, M.x2))
+#     M.sub.o = Objective(expr=11 * M.x2 + 12 * M.x2 * M.y1 + M.y2 + 9 * M.y3)
+#     M.sub.c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
+#     M.sub.c2 = Constraint(expr=20 <= 2 * M.x1 + 6 * M.y1 + 14 * M.x2 * M.y2 + 10 * M.y3)
+#     M.sub.c3 = Constraint(expr=32 == 4 * M.x1 + 8 * M.y1 + 15 * M.x2 * M.y4)
+#     M.sub.c4 = Constraint(expr=inequality(22, 3 * M.x1 + 7 * M.y1 + 16 * M.x2 * M.y3, 28))
+#
+#     M.T = range(2)
+#     M.block = Block(M.T)
+#
+#     for t in M.T:
+#         M.block[t].c1 = Constraint(expr=M.x1 + 13 * M.x2 * M.y1 + 5 * M.y1 <= 19)
+#
+#     M.hp = create_submodel_hp_block(M)
+#     M.hp.pprint()

--- a/pao/bilevel/tests/auxiliary/reformulation/besancon27.txt
+++ b/pao/bilevel/tests/auxiliary/reformulation/besancon27.txt
@@ -14,17 +14,7 @@
         Key  : Lower : Body          : Upper : Active
         None :  -Inf : 1 - 0.1*x - v :   0.0 :   True
 2 Block Declarations
-    sub : Size=1, Index=None, Active=True
-        1 Objective Declarations
-            o : Size=1, Index=None, Active=True
-                Key  : Active : Sense    : Expression
-                None :   True : maximize :          v
-        1 Constraint Declarations
-            c1 : Size=1, Index=None, Active=True
-                Key  : Lower : Body            : Upper : Active
-                None :  -Inf : v - (1 + 0.1*x) :   0.0 :   True
-        2 Declarations: o c1
-    sub_hp : Size=1, Index=None, Active=False
+    hpr : Size=1, Index=None, Active=False
         5 Set Declarations
             c1_index : Dim=0, Dimen=1, Size=1, Domain=None, Ordered=False, Bounds=(None, None)
                 [None]
@@ -37,22 +27,32 @@
             x_index : Dim=0, Dimen=1, Size=1, Domain=None, Ordered=False, Bounds=(None, None)
                 [None]
         2 Var Declarations
-            v : Size=1, Index=sub_hp.v_index
+            v : Size=1, Index=hpr.v_index
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :  None :  None :  None : False :  True :  Reals
-            x : Size=1, Index=sub_hp.x_index
+            x : Size=1, Index=hpr.x_index
                 Key  : Lower : Value : Upper : Fixed : Stale : Domain
                 None :     0 :  None :  None : False :  True : NonNegativeReals
         1 Objective Declarations
-            o : Size=1, Index=sub_hp.o_index, Active=True
+            o : Size=1, Index=hpr.o_index, Active=True
                 Key  : Active : Sense    : Expression
                 None :   True : minimize :          x
         2 Constraint Declarations
-            c1 : Size=1, Index=sub_hp.c1_index, Active=True
+            c1 : Size=1, Index=hpr.c1_index, Active=True
                 Key  : Lower : Body          : Upper : Active
                 None :  -Inf : 1 - 0.1*x - v :   0.0 :   True
-            sub.c1 : Size=1, Index=sub_hp.sub.c1_index, Active=True
+            sub.c1 : Size=1, Index=hpr.sub.c1_index, Active=True
                 Key  : Lower : Body            : Upper : Active
                 None :  -Inf : v - (1 + 0.1*x) :   0.0 :   True
-        10 Declarations: o_index o x_index x v_index v c1_index c1 sub.c1_index sub.c1
-6 Declarations: x v o c1 sub sub_hp
+        10 Declarations: o_index o v_index v x_index x c1_index c1 sub.c1_index sub.c1
+    sub : Size=1, Index=None, Active=True
+        1 Objective Declarations
+            o : Size=1, Index=None, Active=True
+                Key  : Active : Sense    : Expression
+                None :   True : maximize :          v
+        1 Constraint Declarations
+            c1 : Size=1, Index=None, Active=True
+                Key  : Lower : Body            : Upper : Active
+                None :  -Inf : v - (1 + 0.1*x) :   0.0 :   True
+        2 Declarations: o c1
+6 Declarations: x v o c1 sub hpr

--- a/pao/bilevel/tests/test_highpoint.py
+++ b/pao/bilevel/tests/test_highpoint.py
@@ -125,7 +125,7 @@ class TestHighpointSolve(unittest.TestCase):
 
         solver = SolverFactory(numerical_solver)
         for c in instance.component_objects(Block, descend_into=False):
-            if '_hp' in c.name:
+            if 'hpr' in c.name:
                 c.activate()
                 results = solver.solve(c, tee=True, keepfiles=True)
                 c.deactivate()

--- a/pao/bilevel/tests/test_highpoint.py
+++ b/pao/bilevel/tests/test_highpoint.py
@@ -189,5 +189,6 @@ class TestHighpointSolve(unittest.TestCase):
                 ans[name] = value(data)
         return ans
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Did not include Runtime Error for when components on the block for which we are adding References already contain the same object name because this error is handled by Pyomo on the backend.