### PR TITLE
Initial implementation of stochastic bilevel interdiction

### DIFF
--- a/pao/bilevel/plugins/__init__.py
+++ b/pao/bilevel/plugins/__init__.py
@@ -27,4 +27,7 @@ def load():
     import pao.bilevel.solvers.solver2
     import pao.bilevel.solvers.solver3
     import pao.bilevel.solvers.solver4
+    import pao.bilevel.solvers.solver5
+    import pao.bilevel.solvers.solver6
+    import pao.bilevel.solvers.solver7
 

--- a/pao/bilevel/plugins/dual.py
+++ b/pao/bilevel/plugins/dual.py
@@ -35,13 +35,18 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
     def _apply_to(self, model, **kwds):
         submodel_name = kwds.pop('submodel', None)
         use_dual_objective = kwds.pop('use_dual_objective', False)
+        subproblem_objective_weights = kwds.pop('subproblem_objective_weights', None)
         #
         # Process options
         #
         self._preprocess('pao.bilevel.linear_dual', model)
         self._fix_all()
 
+        _dual_obj = 0.
+        _dual_sense = None
+        _primal_obj = 0.
         for key, sub in self.submodel.items():
+            _parent = sub.parent_block()
             #
             # Generate the dual block
             #
@@ -53,16 +58,18 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
             if use_dual_objective:
                 #
                 # Deactivate the upper-level objective, and
-                # defaults to use the objective of the last SubModel iterated.
+                # defaults to use the aggregate objective of the SubModels.
                 #
-
-                for odata in sub.component_objects(Objective, active=True):
-                    _oid = id(odata)
-                    break
+                for odata in dual.component_objects(Objective, active=True):
+                    if subproblem_objective_weights:
+                        _dual_obj += subproblem_objective_weights[_parent.index()]*odata.expr
+                    else:
+                        _dual_obj += odata.expr
+                    _dual_sense = odata.sense # TODO: currently assumes all subproblems have same sense
+                    odata.deactivate()
 
                 for odata in model.component_objects(Objective, active=True):
-                    if id(odata) != _oid:
-                        odata.deactivate()
+                    odata.deactivate()
             else:
                 #
                 # Add a constraint that maps the dual objective to the primal objective
@@ -72,16 +79,19 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
                 # But that transformation would not be limited to the submodel.  If that's
                 # an issue for a user, they can make that change, and see the benefit.
                 #
-                dual_obj = None
                 for odata in dual.component_objects(Objective, active=True):
-                    dual_obj = odata
-                    dual_obj.deactivate()
-                    break
-                primal_obj = None
+                    if subproblem_objective_weights:
+                        _dual_obj += subproblem_objective_weights[_parent.index()]*odata.expr
+                    else:
+                        _dual_obj += odata.expr
+                    odata.deactivate()
+
                 for odata in sub.component_objects(Objective, active=True):
-                    primal_obj = odata
-                    break
-                dual.equiv_objs = Constraint(expr=dual_obj.expr == primal_obj.expr)
+                    if subproblem_objective_weights:
+                        _primal_obj += subproblem_objective_weights[_parent.index()]*odata.expr
+                    else:
+                        _primal_obj += odata.expr
+
             #
             # Add the dual block
             #
@@ -89,7 +99,6 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
             # first check if the submodel exists on a _BlockData,
             # otherwise add the dual block to the model directly
             _dual_name = key +'_dual'
-            _parent = sub.parent_block()
             if type(_parent) == _BlockData:
                 _dual_name = _dual_name.replace(_parent.name+".","")
                 _parent.add_component(_dual_name, dual)
@@ -105,9 +114,13 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
             #
             # Disable the original submodel
             #
-            # Q: Are the last steps redundant?  Will we recurse into deactivated blocks?
-            #
             sub.deactivate()
             for data in sub.component_map(active=True).values():
                 if not isinstance(data, Var) and not isinstance(data, Set):
                     data.deactivate()
+
+        # TODO: with multiple sub-problems, put the _obj or equiv_objs on a separate block
+        if use_dual_objective:
+            dual._obj = Objective(expr=_dual_obj, sense=_dual_sense)
+        else:
+            dual.equiv_objs = Constraint(expr=_dual_obj == _primal_obj)

--- a/pao/bilevel/plugins/dual.py
+++ b/pao/bilevel/plugins/dual.py
@@ -55,19 +55,19 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
             #
             # Figure out which objective is being used
             #
+            for odata in dual.component_objects(Objective, active=True):
+                if subproblem_objective_weights:
+                    _dual_obj += subproblem_objective_weights[key] * odata.expr
+                else:
+                    _dual_obj += odata.expr
+                _dual_sense = odata.sense  # TODO: currently assumes all subproblems have same sense
+                odata.deactivate()
+
             if use_dual_objective:
                 #
                 # Deactivate the upper-level objective, and
                 # defaults to use the aggregate objective of the SubModels.
                 #
-                for odata in dual.component_objects(Objective, active=True):
-                    if subproblem_objective_weights:
-                        _dual_obj += subproblem_objective_weights[_parent.index()]*odata.expr
-                    else:
-                        _dual_obj += odata.expr
-                    _dual_sense = odata.sense # TODO: currently assumes all subproblems have same sense
-                    odata.deactivate()
-
                 for odata in model.component_objects(Objective, active=True):
                     odata.deactivate()
             else:
@@ -79,16 +79,9 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
                 # But that transformation would not be limited to the submodel.  If that's
                 # an issue for a user, they can make that change, and see the benefit.
                 #
-                for odata in dual.component_objects(Objective, active=True):
-                    if subproblem_objective_weights:
-                        _dual_obj += subproblem_objective_weights[_parent.index()]*odata.expr
-                    else:
-                        _dual_obj += odata.expr
-                    odata.deactivate()
-
                 for odata in sub.component_objects(Objective, active=True):
                     if subproblem_objective_weights:
-                        _primal_obj += subproblem_objective_weights[_parent.index()]*odata.expr
+                        _primal_obj += subproblem_objective_weights[key]*odata.expr
                     else:
                         _primal_obj += odata.expr
 
@@ -122,5 +115,5 @@ class LinearDualBilevelTransformation(BaseBilevelTransformation):
         # TODO: with multiple sub-problems, put the _obj or equiv_objs on a separate block
         if use_dual_objective:
             dual._obj = Objective(expr=_dual_obj, sense=_dual_sense)
-        else:
-            dual.equiv_objs = Constraint(expr=_dual_obj == _primal_obj)
+
+        dual.equiv_objs = Constraint(expr=_dual_obj == _primal_obj)

--- a/pao/bilevel/solvers/solver1.py
+++ b/pao/bilevel/solvers/solver1.py
@@ -127,7 +127,9 @@ class BilevelSolver1(pyomo.opt.OptSolver):
                     submodel = self._instance.find_component(name_)
                     submodel.activate()
                     for data in submodel.component_map(active=False).values():
-                        if not isinstance(data, Var) and not isinstance(data, Set):
+                        if not isinstance(data, Objective):
+                            data.activate()
+                        if isinstance(data, Objective) and self.use_dual_objective:
                             data.activate()
                     _dual_name = name_+'_dual'
                     _parent = submodel.parent_block()
@@ -144,20 +146,20 @@ class BilevelSolver1(pyomo.opt.OptSolver):
                     # solver plugin always occurs thereby avoiding memory
                     # leaks caused by plugins!
                     #
-                    with pyomo.opt.SolverFactory(solver) as opt_inner:
-                        #
-                        # **NOTE: It would be better to override _presolve on the
-                        #         base class of this solver as you might be
-                        #         missing a number of keywords that were passed
-                        #         into the solve method (e.g., none of the
-                        #         io_options are getting relayed to the subsolver
-                        #         here).
-                        #
-                        #opt_inner.options['mipgap'] = self.options.get('mipgap', 0.001)
-                        results = opt_inner.solve(self._instance,
-                                                  tee=self._tee,
-                                                  timelimit=self._timelimit)
-                        self.results.append(results)
+                with pyomo.opt.SolverFactory(solver) as opt_inner:
+                    #
+                    # **NOTE: It would be better to override _presolve on the
+                    #         base class of this solver as you might be
+                    #         missing a number of keywords that were passed
+                    #         into the solve method (e.g., none of the
+                    #         io_options are getting relayed to the subsolver
+                    #         here).
+                    #
+                    #opt_inner.options['mipgap'] = self.options.get('mipgap', 0.001)
+                    results = opt_inner.solve(self._instance,
+                                              tee=self._tee,
+                                              timelimit=self._timelimit)
+                    self.results.append(results)
 
                 # Unfix variables
                 for v in tdata.fixed:

--- a/pao/bilevel/solvers/solver1.py
+++ b/pao/bilevel/solvers/solver1.py
@@ -131,9 +131,7 @@ class BilevelSolver1(pyomo.opt.OptSolver):
                     submodel = self._instance.find_component(name_)
                     submodel.activate()
                     for data in submodel.component_map(active=False).values():
-                        if not isinstance(data, Objective):
-                            data.activate()
-                        if isinstance(data, Objective) and self.use_dual_objective:
+                        if not isinstance(data, Var) and not isinstance(data, Set):
                             data.activate()
                     _dual_name = name_+'_dual'
                     _parent = submodel.parent_block()

--- a/pao/bilevel/solvers/solver5.py
+++ b/pao/bilevel/solvers/solver5.py
@@ -26,6 +26,7 @@ import time
 import pyutilib.misc
 import pyomo.opt
 import pyomo.common
+from pyomo.opt import TerminationCondition
 from pyomo.core import TransformationFactory, Var, Set, Block
 from .solver3 import BilevelSolver3
 

--- a/pao/bilevel/solvers/solver7.py
+++ b/pao/bilevel/solvers/solver7.py
@@ -130,7 +130,7 @@ class BilevelSolver7(pyomo.opt.OptSolver):
                     submodel = self._instance.find_component(name_)
                     submodel.activate()
                     for data in submodel.component_map(active=False).values():
-                        if not isinstance(data, Objective):
+                        if not isinstance(data, Var) and not isinstance(data, Set) and not isinstance(data, Objective):
                             data.activate()
                     _dual_name = name_+'_dual'
                     _parent = submodel.parent_block()

--- a/pao/bilevel/tests/auxiliary/t5.py
+++ b/pao/bilevel/tests/auxiliary/t5.py
@@ -18,7 +18,7 @@ from pao.bilevel import *
 def pyomo_create_model():
 
     model = ConcreteModel()
-    model.z = Var(bounds=(1,2))
+    model.z = Var(bounds=(1,2), initialize=1)
     model.x1 = Var(within=NonNegativeReals)
     model.x2 = Var(within=NonNegativeReals)
     model.o = Objective(expr=model.z*(3*model.x1 + 2.5*model.x2), sense=minimize)
@@ -33,3 +33,6 @@ def pyomo_create_model():
     model.sub.c4 = Constraint(expr=3*model.x1 + 6*model.x2 <= 100)
 
     return model
+
+if __name__ == "__main__":
+    m = pyomo_create_model()

--- a/pao/bilevel/tests/test_highpoint.py
+++ b/pao/bilevel/tests/test_highpoint.py
@@ -127,7 +127,7 @@ class TestHighpointSolve(unittest.TestCase):
         for c in instance.component_objects(Block, descend_into=False):
             if 'hpr' in c.name:
                 c.activate()
-                results = solver.solve(c, tee=True, keepfiles=True)
+                results = solver.solve(c, tee=False, keepfiles=True)
                 c.deactivate()
 
         self.assertTrue(results.solver.termination_condition == pyomo.opt.TerminationCondition.optimal)

--- a/pao/bilevel/tests/test_linear_bilevel.py
+++ b/pao/bilevel/tests/test_linear_bilevel.py
@@ -30,7 +30,7 @@ except ImportError:
     yaml_available=False
 
 # only runs with no error when solvers = ['ipopt'] and pao_solvers = ['pao.bilevel.blp_local']
-solvers = solvers = ['ipopt'] #pyomo.opt.check_available_solvers('cplex','glpk','gurobi','ipopt')
+solvers = ['ipopt'] #pyomo.opt.check_available_solvers('cplex','glpk','gurobi','ipopt')
 pao_solvers = ['pao.bilevel.blp_local']#,'pao.bilevel.blp_global']
 solvers2 = pyomo.opt.check_available_solvers('cplex','glpk','gurobi','ipopt')
 pao_solvers2 = ['pao.bilevel.ld']
@@ -132,7 +132,6 @@ class TestBilevelSolve(unittest.TestCase):
         from importlib.machinery import SourceFileLoader
         namespace = SourceFileLoader(name,model).load_module()
         instance = namespace.pyomo_create_model()
-
         solver = SolverFactory(pao_solver)
         solver.options.solver = numerical_solver
         results = solver.solve(instance, tee=False)


### PR DESCRIPTION
Needs further testing, see solver7. This approach assumes multiple an upper-level objective that is the weighted expectation across the submodels, and multiple lower-level objectives with opposite sense to that of the upper-level (thus, the interdiction). 