### PR TITLE
Updates to add references for variables; updates to requiring weights be specified for stochastic interdiction.

### DIFF
--- a/pao/bilevel/components.py
+++ b/pao/bilevel/components.py
@@ -29,9 +29,9 @@ def varref(model, origin=None, vars=None):
     a bilevel model exist only on the parent_block() for ConcreteModel()
     """
 
-    # default to parent block
+    # default to root block
     if not origin:
-        origin = model.parent_block()
+        origin = model.root_block()
 
     # intersection of 2 Pyomo var lists
     def _intersection(list1, list2):
@@ -62,7 +62,7 @@ def dataref(model, origin=None):
     """
     # default to parent block
     if not origin:
-        origin = model.parent_block()
+        origin = model.root_block()
 
     for p in origin.component_objects(Param, descend_into=False):
         model.add_component(p.name, Reference(p))

--- a/pao/bilevel/solvers/solver7.py
+++ b/pao/bilevel/solvers/solver7.py
@@ -54,6 +54,9 @@ class BilevelSolver7(pyomo.opt.OptSolver):
         #
         # Cache the instance
         #
+        if self.subproblem_objective_weights is None:
+            raise Exception('Problem encountered, expected probability weights.')
+
         xfrm = TransformationFactory('pao.bilevel.linear_dual')
         xfrm.apply_to(self._instance, use_dual_objective=self.use_dual_objective, \
                       subproblem_objective_weights=self.subproblem_objective_weights)


### PR DESCRIPTION
Made sure that add references occurs from root_block() and not parent_block() -- this assumes all relevant global variables are on the main ConcreteModel. Updated solver7 to *require* an input specifying the objective function weights